### PR TITLE
Add cargo fmt pre-commit hook

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,6 @@
+pre-commit:
+  commands:
+    cargo-fmt:
+      glob: "*.rs"
+      run: rustfmt --edition 2021 --emit files {staged_files}
+      stage_fixed: true

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ A server that receives withdrawal requests from users and writes them to the dat
 
 install [lefthook](https://github.com/evilmartians/lefthook):
 
-
 ```bash
 brew install lefthook
 ```

--- a/README.md
+++ b/README.md
@@ -99,3 +99,20 @@ A server that receives transactions from users and generates blocks.
 
 **withdrawal-server:**
 A server that receives withdrawal requests from users and writes them to the database.
+
+# For Developer
+
+## Set-up Local Environment
+
+install [lefthook](https://github.com/evilmartians/lefthook):
+
+
+```bash
+brew install lefthook
+```
+
+and initial setup:
+
+```bash
+lefthook install
+```


### PR DESCRIPTION
Introduced lefthook for git hooks management.
Currently, it automates rust code formatting (`rustfmt` same as `cargo fmt`) as a pre-commit hook.

## Changes

* Added lefthook configuration file (.lefthook.yml)
* Configured rustfmt to run on pre-commit
* Added lefthook setup instructions to README

## Pros

* Automates code formatting standardization, reducing review workload
* Eliminates the need for format-fixing commits by formatting before commit
* Enables team-wide sharing of git hooks, making development environment standardization easier
* Lefthook is lightweight and easy to set up