### PR TITLE
Add Dependabot configuration for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # for Rust packages
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    allow:
+      - dependency-type: "direct"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
Introduced Dependabot for automated dependency updates.
It checks for updates in both Rust packages and GitHub Actions dependencies on a weekly basis.

## Changes

* Added Dependabot configuration file (.github/dependabot.yml)
* Added Cargo package update settings (weekly, direct dependencies only)
* Added GitHub Actions update settings (weekly)
* Configured automatic labeling for PRs
* Defined commit message format (Cargo: chore, Actions: ci)

## Pros

* Improves security through automated dependency updates
* Weekly updates keep update scope manageable
* PR limit (max 5) helps manage review workload
* Automatic labels and commit messages make changes easily trackable
* Limiting to direct dependencies prevents unnecessary updates