### PR TITLE
Add clippy to pre-commit hook and fix warnings

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -7,6 +7,6 @@ pre-commit:
       stage_fixed: true
     cargo-clippy:
       glob: "*.rs"
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --tests -- -D warnings
     check-typos:
       run: typos {staged_files}

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,8 +1,12 @@
 pre-commit:
+  parallel: true
   commands:
     cargo-fmt:
       glob: "*.rs"
       run: rustfmt --edition 2021 --emit files {staged_files}
       stage_fixed: true
+    cargo-clippy:
+      glob: "*.rs"
+      run: cargo clippy -- -D warnings
     check-typos:
       run: typos {staged_files}

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ A server that receives withdrawal requests from users and writes them to the dat
 
 ## Set-up Local Environment
 
+initial setup for Rust Tools:
+
+```bash
+rustup component add rustfmt clippy
+```
+
 install [lefthook](https://github.com/evilmartians/lefthook):
 
 ```bash

--- a/balance-prover/src/api/api.rs
+++ b/balance-prover/src/api/api.rs
@@ -17,7 +17,7 @@ pub async fn prove_spent(
 ) -> Result<Json<ProveResponse>, Error> {
     let proof = state
         .prove_spent(&request.spent_witness)
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 
@@ -34,7 +34,7 @@ pub async fn prove_send(
             &request.spent_proof,
             &request.prev_proof,
         )
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 
@@ -45,7 +45,7 @@ pub async fn prove_update(
 ) -> Result<Json<ProveResponse>, Error> {
     let proof = state
         .prove_update(request.pubkey, &request.update_witness, &request.prev_proof)
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 
@@ -61,7 +61,7 @@ pub async fn prove_receive_transfer(
             &request.receive_transfer_witness,
             &request.prev_proof,
         )
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 
@@ -77,7 +77,7 @@ pub async fn prove_receive_deposit(
             &request.receive_deposit_witness,
             &request.prev_proof,
         )
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 
@@ -89,7 +89,7 @@ pub async fn prove_single_withdrawal(
     let request = request.into_inner();
     let proof = state
         .prove_single_withdrawal(&request.withdrawal_witness)
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(ProveResponse { proof }))
 }
 

--- a/balance-prover/src/api/balance_prover.rs
+++ b/balance-prover/src/api/balance_prover.rs
@@ -63,7 +63,7 @@ impl BalanceProver {
             .balance_processor
             .balance_transition_processor
             .sender_processor
-            .prove_spent(&spent_witness)
+            .prove_spent(spent_witness)
             .map_err(|e| BalanceProverError::ProveSpentError(e.to_string()))?;
         Ok(spent_proof)
     }
@@ -124,7 +124,7 @@ impl BalanceProver {
     ) -> Result<ProofWithPublicInputs<F, C, D>, BalanceProverError> {
         let balance_proof = self
             .balance_processor
-            .prove_receive_deposit(pubkey, &receive_deposit_witness, prev_proof)
+            .prove_receive_deposit(pubkey, receive_deposit_witness, prev_proof)
             .map_err(|e| BalanceProverError::ProveReceiveDepositError(e.to_string()))?;
         Ok(balance_proof)
     }

--- a/balance-prover/src/api/mod.rs
+++ b/balance-prover/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod api;
 pub mod balance_prover;
 pub mod error;

--- a/block-builder/src/api/api.rs
+++ b/block-builder/src/api/api.rs
@@ -18,7 +18,7 @@ pub async fn post_empty_block(state: Data<State>) -> Result<Json<()>, Error> {
     state
         .evoke_force_post()
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 
@@ -47,7 +47,7 @@ pub async fn tx_request(
         .await
         .send_tx_request(request.is_registration_block, request.pubkey, request.tx)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 
@@ -62,7 +62,7 @@ pub async fn query_proposal(
         .read()
         .await
         .query_proposal(request.is_registration_block, request.pubkey, request.tx)
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(QueryProposalResponse { block_proposal }))
 }
 
@@ -81,7 +81,7 @@ pub async fn post_signature(
         .write()
         .await
         .post_signature(request.is_registration_block, request.tx, user_signature)
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 

--- a/block-builder/src/api/block_builder.rs
+++ b/block-builder/src/api/block_builder.rs
@@ -118,10 +118,8 @@ impl BlockBuilder {
                     pubkey, account_id,
                 ));
             }
-        } else {
-            if account_info.account_id.is_none() {
-                return Err(BlockBuilderError::AccountNotFound(pubkey));
-            }
+        } else if account_info.account_id.is_none() {
+            return Err(BlockBuilderError::AccountNotFound(pubkey));
         }
 
         // update state
@@ -178,12 +176,10 @@ impl BlockBuilder {
         if status.is_pausing() {
             return Err(BlockBuilderError::BlockBuilderIsPausing);
         }
-        if status.is_accepting_txs() {
-            if !status.is_request_contained(pubkey, tx) {
-                return Err(BlockBuilderError::TxRequestNotFound);
-            }
+        if status.is_accepting_txs() && !status.is_request_contained(pubkey, tx) {
+            return Err(BlockBuilderError::TxRequestNotFound);
         }
-        return Ok(status.query_proposal(pubkey, tx));
+        Ok(status.query_proposal(pubkey, tx))
     }
 
     // Post the signature by the user.

--- a/block-builder/src/api/internal_state.rs
+++ b/block-builder/src/api/internal_state.rs
@@ -47,6 +47,12 @@ pub enum BuilderState {
     ProposingBlock(ProposingBlockState), // after constructed the block, accepting signatures for the block
 }
 
+impl Default for BuilderState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BuilderState {
     pub fn new() -> Self {
         BuilderState::Pausing
@@ -61,24 +67,15 @@ impl BuilderState {
     }
 
     pub fn is_pausing(&self) -> bool {
-        match self {
-            BuilderState::Pausing => true,
-            _ => false,
-        }
+        matches!(self, BuilderState::Pausing)
     }
 
     pub fn is_accepting_txs(&self) -> bool {
-        match self {
-            BuilderState::AcceptingTxs(_) => true,
-            _ => false,
-        }
+        matches!(self, BuilderState::AcceptingTxs(_))
     }
 
     pub fn is_proposing_block(&self) -> bool {
-        match self {
-            BuilderState::ProposingBlock(_) => true,
-            _ => false,
-        }
+        matches!(self, BuilderState::ProposingBlock(_))
     }
 
     pub fn is_request_contained(&self, pubkey: U256, tx: Tx) -> bool {
@@ -161,7 +158,7 @@ impl BuilderState {
 
         let mut tx_tree = TxTree::new(TX_TREE_HEIGHT);
         for (_, tx) in sorted_and_padded_txs.iter() {
-            tx_tree.push(tx.clone());
+            tx_tree.push(*tx);
         }
         let tx_tree_root: Bytes32 = tx_tree.get_root().into();
 

--- a/block-builder/src/api/mod.rs
+++ b/block-builder/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod api;
 pub mod block_builder;
 pub mod error;

--- a/block-builder/src/api/state.rs
+++ b/block-builder/src/api/state.rs
@@ -44,7 +44,7 @@ impl State {
     pub async fn main_job(self, is_registration_block: bool) {
         actix_web::rt::spawn(async move {
             loop {
-                if self.is_shutting_down.read().await.clone() {
+                if *self.is_shutting_down.read().await {
                     log::info!("Shutting down block builder");
                     break;
                 }

--- a/block-builder/src/main.rs
+++ b/block-builder/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> std::io::Result<()> {
         env.rollup_contract_address,
         env.rollup_contract_deployed_block_number,
         env.block_builder_private_key,
-        eth_allowance_for_block.into(),
+        eth_allowance_for_block,
         &env.validity_prover_base_url,
     );
     let state = State::new(block_builder);

--- a/cli/src/cli/get.rs
+++ b/cli/src/cli/get.rs
@@ -14,7 +14,7 @@ use super::error::CliError;
 
 pub async fn balance(key: KeySet) -> Result<(), CliError> {
     let client = get_client()?;
-    let pending_info = client.sync(key.clone()).await?;
+    let pending_info = client.sync(key).await?;
 
     println!("Pending deposits: {}", pending_info.pending_deposits.len());
     println!(
@@ -28,11 +28,10 @@ pub async fn balance(key: KeySet) -> Result<(), CliError> {
 
     println!("Balances:");
     for (i, leaf) in balances.iter() {
-        let (token_type, address, token_id) =
-            client.liquidity_contract.get_token_info(*i as u32).await?;
+        let (token_type, address, token_id) = client.liquidity_contract.get_token_info(*i).await?;
         println!("\t Token #{}:", i);
         println!("\t\t Amount: {}", leaf.amount);
-        println!("\t\t Type: {}", token_type.to_string());
+        println!("\t\t Type: {}", token_type);
 
         match token_type {
             TokenType::NATIVE => {}

--- a/cli/src/cli/utils.rs
+++ b/cli/src/cli/utils.rs
@@ -8,14 +8,11 @@ use super::error::CliError;
 pub fn convert_u256(input: U256) -> intmax2_zkp::ethereum_types::u256::U256 {
     let mut bytes = [0u8; 32];
     input.to_big_endian(&mut bytes);
-    let amount = intmax2_zkp::ethereum_types::u256::U256::from_bytes_be(&bytes);
-    amount
+    intmax2_zkp::ethereum_types::u256::U256::from_bytes_be(&bytes)
 }
 
 pub fn convert_address(input: Address) -> intmax2_zkp::ethereum_types::address::Address {
-    let address =
-        intmax2_zkp::ethereum_types::address::Address::from_bytes_be(&input.to_fixed_bytes());
-    address
+    intmax2_zkp::ethereum_types::address::Address::from_bytes_be(&input.to_fixed_bytes())
 }
 
 pub fn load_env() -> Result<EnvVar, CliError> {
@@ -33,7 +30,7 @@ pub async fn post_empty_block() -> Result<(), CliError> {
         "BLOCK_BUILDER_BASE_URL".to_string(),
     ))?;
     reqwest::Client::new()
-        .post(&format!(
+        .post(format!(
             "{}/block-builder/post-empty-block",
             block_builder_base_url
         ))

--- a/cli/src/format.rs
+++ b/cli/src/format.rs
@@ -23,29 +23,26 @@ pub fn format_token_info(
 ) -> Result<(EthU256, EthAddress, EthU256), FormatTokenInfoError> {
     match token_type {
         TokenType::NATIVE => Ok({
-            let amount = amount.ok_or_else(|| FormatTokenInfoError::MissingAmount)?;
+            let amount = amount.ok_or(FormatTokenInfoError::MissingAmount)?;
             (amount, EthAddress::zero(), EthU256::zero())
         }),
         TokenType::ERC20 => {
-            let amount = amount.ok_or_else(|| FormatTokenInfoError::MissingAmount)?;
-            let token_address =
-                token_address.ok_or_else(|| FormatTokenInfoError::MissingTokenAddress)?;
+            let amount = amount.ok_or(FormatTokenInfoError::MissingAmount)?;
+            let token_address = token_address.ok_or(FormatTokenInfoError::MissingTokenAddress)?;
             Ok((amount, token_address, EthU256::zero()))
         }
         TokenType::ERC721 => {
             if amount.is_some() {
-                return Err(FormatTokenInfoError::AmountShouldNotBeSpecified.into());
+                return Err(FormatTokenInfoError::AmountShouldNotBeSpecified);
             }
-            let token_address =
-                token_address.ok_or_else(|| FormatTokenInfoError::MissingTokenAddress)?;
-            let token_id = token_id.ok_or_else(|| FormatTokenInfoError::MissingTokenId)?;
+            let token_address = token_address.ok_or(FormatTokenInfoError::MissingTokenAddress)?;
+            let token_id = token_id.ok_or(FormatTokenInfoError::MissingTokenId)?;
             Ok((EthU256::one(), token_address, token_id))
         }
         TokenType::ERC1155 => {
-            let amount = amount.ok_or_else(|| FormatTokenInfoError::MissingAmount)?;
-            let token_address =
-                token_address.ok_or_else(|| FormatTokenInfoError::MissingTokenAddress)?;
-            let token_id = token_id.ok_or_else(|| FormatTokenInfoError::MissingTokenId)?;
+            let amount = amount.ok_or(FormatTokenInfoError::MissingAmount)?;
+            let token_address = token_address.ok_or(FormatTokenInfoError::MissingTokenAddress)?;
+            let token_id = token_id.ok_or(FormatTokenInfoError::MissingTokenId)?;
             Ok((amount, token_address, token_id))
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -58,7 +58,7 @@ async fn main_process(command: Commands) -> Result<(), CliError> {
             let key = h256_to_keyset(private_key);
             let transfer_input = TransferInput {
                 recipient: to,
-                amount: amount.into(),
+                amount,
                 token_index,
             };
             transfer(key, &[transfer_input]).await?;

--- a/client-sdk/src/client/client.rs
+++ b/client-sdk/src/client/client.rs
@@ -156,7 +156,7 @@ where
         transfers: Vec<Transfer>,
     ) -> Result<TxRequestMemo, ClientError> {
         // input validation
-        if transfers.len() == 0 {
+        if transfers.is_empty() {
             return Err(ClientError::TransferLenError(
                 "transfers is empty".to_string(),
             ));
@@ -294,7 +294,7 @@ where
         let common_tx_data = CommonTxData {
             spent_proof: memo.spent_proof.clone(),
             sender_prev_block_number: memo.prev_block_number,
-            tx: memo.tx.clone(),
+            tx: memo.tx,
             tx_index: proposal.tx_index,
             tx_merkle_proof: proposal.tx_merkle_proof.clone(),
             tx_tree_root: proposal.tx_tree_root,
@@ -312,7 +312,7 @@ where
         // save transfer data
         let mut transfer_tree = TransferTree::new(TRANSFER_TREE_HEIGHT);
         for transfer in &memo.transfers {
-            transfer_tree.push(transfer.clone());
+            transfer_tree.push(*transfer);
         }
 
         let mut all_transfer_data_vec = Vec::new();
@@ -323,7 +323,7 @@ where
                 prev_block_number: memo.prev_block_number,
                 prev_private_commitment: memo.prev_private_commitment,
                 tx_data: common_tx_data.clone(),
-                transfer: transfer.clone(),
+                transfer: *transfer,
                 transfer_index: i as u32,
                 transfer_merkle_proof,
             };

--- a/client-sdk/src/client/key_from_eth.rs
+++ b/client-sdk/src/client/key_from_eth.rs
@@ -66,7 +66,7 @@ mod test {
 
         for test_case in test_cases.iter() {
             let account = generate_intmax_account_from_eth_key(test_case.private_key);
-            assert_eq!(account.is_dummy, false);
+            assert!(!account.is_dummy);
             assert_eq!(account.pubkey.to_hex(), test_case.public_key);
         }
     }

--- a/client-sdk/src/client/mod.rs
+++ b/client-sdk/src/client/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod client;
 pub mod config;
 pub mod error;

--- a/client-sdk/src/client/strategy/deposit.rs
+++ b/client-sdk/src/client/strategy/deposit.rs
@@ -62,20 +62,18 @@ pub async fn fetch_deposit_info<S: StoreVaultClientInterface, V: ValidityProverC
                     let mut meta = meta;
                     meta.block_number = Some(deposit_info.block_number);
                     settled.push((meta, deposit_data));
+                } else if meta.timestamp + deposit_timeout < chrono::Utc::now().timestamp() as u64 {
+                    // timeout
+                    log::error!(
+                        "Deposit uuid: {}, hash: {} is timeout",
+                        meta.uuid,
+                        deposit_hash
+                    );
+                    timeout.push((meta, deposit_data));
                 } else {
-                    if meta.timestamp + deposit_timeout < chrono::Utc::now().timestamp() as u64 {
-                        // timeout
-                        log::error!(
-                            "Deposit uuid: {}, hash: {} is timeout",
-                            meta.uuid,
-                            deposit_hash
-                        );
-                        timeout.push((meta, deposit_data));
-                    } else {
-                        // pending
-                        log::info!("Deposit {} is pending", meta.uuid);
-                        pending.push((meta, deposit_data));
-                    }
+                    // pending
+                    log::info!("Deposit {} is pending", meta.uuid);
+                    pending.push((meta, deposit_data));
                 }
             }
             Err(e) => {

--- a/client-sdk/src/client/strategy/mod.rs
+++ b/client-sdk/src/client/strategy/mod.rs
@@ -1,5 +1,6 @@
 pub mod deposit;
 pub mod error;
+#[allow(clippy::module_inception)]
 pub mod strategy;
 pub mod transfer;
 pub mod tx;

--- a/client-sdk/src/client/strategy/strategy.rs
+++ b/client-sdk/src/client/strategy/strategy.rs
@@ -46,7 +46,7 @@ pub enum Action {
 #[derive(Debug, Clone)]
 pub enum ReceiveAction {
     Deposit(MetaData, DepositData),
-    Transfer(MetaData, TransferData<F, C, D>),
+    Transfer(MetaData, Box<TransferData<F, C, D>>),
 }
 
 impl ReceiveAction {
@@ -254,7 +254,7 @@ async fn collect_receives(
         let receive_transfer = transfers
             .iter()
             .filter(|(meta, _)| meta.block_number.unwrap() < block_number)
-            .map(|(meta, data)| ReceiveAction::Transfer(meta.clone(), data.clone()))
+            .map(|(meta, data)| ReceiveAction::Transfer(meta.clone(), Box::new(data.clone())))
             .collect_vec();
         transfers.retain(|(meta, _)| meta.block_number.unwrap() >= block_number);
 
@@ -271,7 +271,7 @@ async fn collect_receives(
 
         let receive_transfer = transfers
             .iter()
-            .map(|(meta, data)| ReceiveAction::Transfer(meta.clone(), data.clone()))
+            .map(|(meta, data)| ReceiveAction::Transfer(meta.clone(), Box::new(data.clone())))
             .collect_vec();
         transfers.clear();
 

--- a/client-sdk/src/client/strategy/transfer.rs
+++ b/client-sdk/src/client/strategy/transfer.rs
@@ -52,16 +52,14 @@ pub async fn fetch_transfer_info<S: StoreVaultClientInterface, V: ValidityProver
                     let mut meta = meta;
                     meta.block_number = Some(block_number);
                     settled.push((meta, transfer_data));
+                } else if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
+                    // timeout
+                    log::error!("Transfer {} is timeout", meta.uuid);
+                    timeout.push((meta, transfer_data));
                 } else {
-                    if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
-                        // timeout
-                        log::error!("Transfer {} is timeout", meta.uuid);
-                        timeout.push((meta, transfer_data));
-                    } else {
-                        // pending
-                        log::info!("Transfer {} is pending", meta.uuid);
-                        pending.push((meta, transfer_data));
-                    }
+                    // pending
+                    log::info!("Transfer {} is pending", meta.uuid);
+                    pending.push((meta, transfer_data));
                 }
             }
             Err(e) => {

--- a/client-sdk/src/client/strategy/tx.rs
+++ b/client-sdk/src/client/strategy/tx.rs
@@ -60,16 +60,14 @@ pub async fn fetch_tx_info<S: StoreVaultClientInterface, V: ValidityProverClient
                     let mut meta = meta;
                     meta.block_number = Some(block_number);
                     settled.push((meta, tx_data));
+                } else if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
+                    // timeout
+                    log::error!("Tx {} is timeout", meta.uuid);
+                    timeout.push((meta, tx_data));
                 } else {
-                    if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
-                        // timeout
-                        log::error!("Tx {} is timeout", meta.uuid);
-                        timeout.push((meta, tx_data));
-                    } else {
-                        // pending
-                        log::info!("Tx {} is pending", meta.uuid);
-                        pending.push((meta, tx_data));
-                    }
+                    // pending
+                    log::info!("Tx {} is pending", meta.uuid);
+                    pending.push((meta, tx_data));
                 }
             }
             Err(e) => {

--- a/client-sdk/src/client/strategy/withdrawal.rs
+++ b/client-sdk/src/client/strategy/withdrawal.rs
@@ -64,16 +64,14 @@ pub async fn fetch_withdrawal_info<
                     let mut meta = meta;
                     meta.block_number = Some(block_number);
                     settled.push((meta, transfer_data));
+                } else if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
+                    // timeout
+                    log::error!("Withdrawal {} is timeout", meta.uuid);
+                    timeout.push((meta, transfer_data));
                 } else {
-                    if meta.timestamp + tx_timeout < chrono::Utc::now().timestamp() as u64 {
-                        // timeout
-                        log::error!("Withdrawal {} is timeout", meta.uuid);
-                        timeout.push((meta, transfer_data));
-                    } else {
-                        // pending
-                        log::info!("Withdrawal {} is pending", meta.uuid);
-                        pending.push((meta, transfer_data));
-                    }
+                    // pending
+                    log::info!("Withdrawal {} is pending", meta.uuid);
+                    pending.push((meta, transfer_data));
                 }
             }
             Err(e) => {

--- a/client-sdk/src/client/sync/balance_logic.rs
+++ b/client-sdk/src/client/sync/balance_logic.rs
@@ -214,8 +214,8 @@ pub async fn update_send_by_sender<
             tx_block_number
         )))?;
     let tx_witness = TxWitness {
-        validity_pis,
-        sender_leaves,
+        validity_pis: validity_pis.clone(),
+        sender_leaves: sender_leaves.clone(),
         tx: tx_data.common.tx,
         tx_index: tx_data.common.tx_index,
         tx_merkle_proof: tx_data.common.tx_merkle_proof.clone(),

--- a/client-sdk/src/client/sync/balance_logic.rs
+++ b/client-sdk/src/client/sync/balance_logic.rs
@@ -101,6 +101,7 @@ pub async fn receive_deposit<V: ValidityProverClientInterface, B: BalanceProverC
     Ok(balance_proof)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn receive_transfer<V: ValidityProverClientInterface, B: BalanceProverClientInterface>(
     validity_prover: &V,
     balance_prover: &B,

--- a/client-sdk/src/client/sync/balance_logic.rs
+++ b/client-sdk/src/client/sync/balance_logic.rs
@@ -69,7 +69,7 @@ pub async fn receive_deposit<V: ValidityProverClientInterface, B: BalanceProverC
         .await?;
     let deposit_witness = DepositWitness {
         deposit_salt: deposit_data.deposit_salt,
-        deposit_index: deposit_info.deposit_index as u32,
+        deposit_index: deposit_info.deposit_index,
         deposit: deposit_data.deposit().unwrap(),
         deposit_merkle_proof,
     };
@@ -94,7 +94,7 @@ pub async fn receive_deposit<V: ValidityProverClientInterface, B: BalanceProverC
             key,
             key.pubkey,
             &receive_deposit_witness,
-            &prev_balance_proof,
+            prev_balance_proof,
         )
         .await?;
 
@@ -124,8 +124,8 @@ pub async fn receive_transfer<V: ValidityProverClientInterface, B: BalanceProver
     }
     // Generate witness
     let transfer_witness = TransferWitness {
-        tx: transfer_data.tx_data.tx.clone(),
-        transfer: transfer_data.transfer.clone(),
+        tx: transfer_data.tx_data.tx,
+        transfer: transfer_data.transfer,
         transfer_index: transfer_data.transfer_index,
         transfer_merkle_proof: transfer_data.transfer_merkle_proof.clone(),
     };
@@ -157,7 +157,7 @@ pub async fn receive_transfer<V: ValidityProverClientInterface, B: BalanceProver
             key,
             key.pubkey,
             &receive_transfer_witness,
-            &prev_balance_proof,
+            prev_balance_proof,
         )
         .await?;
 
@@ -214,9 +214,9 @@ pub async fn update_send_by_sender<
             tx_block_number
         )))?;
     let tx_witness = TxWitness {
-        validity_pis: validity_pis.clone(),
-        sender_leaves: sender_leaves.clone(),
-        tx: tx_data.common.tx.clone(),
+        validity_pis,
+        sender_leaves,
+        tx: tx_data.common.tx,
         tx_index: tx_data.common.tx_index,
         tx_merkle_proof: tx_data.common.tx_merkle_proof.clone(),
     };
@@ -344,7 +344,7 @@ pub async fn update_send_by_receiver<
     let tx_witness = TxWitness {
         validity_pis,
         sender_leaves,
-        tx: common_tx_data.tx.clone(),
+        tx: common_tx_data.tx,
         tx_index: common_tx_data.tx_index,
         tx_merkle_proof: common_tx_data.tx_merkle_proof.clone(),
     };
@@ -385,6 +385,7 @@ pub async fn update_send_by_receiver<
 }
 
 /// Update prev_balance_proof to block_number or do noting if already synced later than block_number.
+///
 /// Assumes that there are no send transactions between the block_number of prev_balance_proof and block_number.
 pub async fn update_no_send<V: ValidityProverClientInterface, B: BalanceProverClientInterface>(
     validity_prover: &V,
@@ -430,7 +431,7 @@ pub async fn update_no_send<V: ValidityProverClientInterface, B: BalanceProverCl
         )));
     }
     let balance_proof = balance_prover
-        .prove_update(key, key.pubkey, &update_witness, &prev_balance_proof)
+        .prove_update(key, key.pubkey, &update_witness, prev_balance_proof)
         .await?;
     Ok(balance_proof)
 }
@@ -440,7 +441,7 @@ pub async fn generate_spent_witness(
     tx_nonce: u32,
     transfers: &[Transfer],
 ) -> Result<SpentWitness, SyncError> {
-    let transfer_tree = generate_transfer_tree(&transfers);
+    let transfer_tree = generate_transfer_tree(transfers);
     let tx = Tx {
         nonce: tx_nonce,
         transfer_tree_root: transfer_tree.get_root(),

--- a/client-sdk/src/client/sync/utils.rs
+++ b/client-sdk/src/client/sync/utils.rs
@@ -13,7 +13,7 @@ pub fn generate_transfer_tree(transfers: &[Transfer]) -> TransferTree {
     transfers.resize(NUM_TRANSFERS_IN_TX, Transfer::default());
     let mut transfer_tree = TransferTree::new(TRANSFER_TREE_HEIGHT);
     for transfer in &transfers {
-        transfer_tree.push(transfer.clone());
+        transfer_tree.push(*transfer);
     }
     transfer_tree
 }

--- a/client-sdk/src/external_api/block_builder.rs
+++ b/client-sdk/src/external_api/block_builder.rs
@@ -19,8 +19,10 @@ use super::utils::query::{get_request, post_request};
 #[derive(Debug, Clone)]
 pub struct BlockBuilderClient;
 
-impl BlockBuilderClient {
-    pub fn new() -> Self {
+impl BlockBuilderClient {}
+
+impl Default for BlockBuilderClient {
+    fn default() -> Self {
         BlockBuilderClient
     }
 }

--- a/client-sdk/src/external_api/block_builder.rs
+++ b/client-sdk/src/external_api/block_builder.rs
@@ -19,11 +19,15 @@ use super::utils::query::{get_request, post_request};
 #[derive(Debug, Clone)]
 pub struct BlockBuilderClient;
 
-impl BlockBuilderClient {}
+impl BlockBuilderClient {
+    pub fn new() -> Self {
+        BlockBuilderClient
+    }
+}
 
 impl Default for BlockBuilderClient {
     fn default() -> Self {
-        BlockBuilderClient
+        BlockBuilderClient::new()
     }
 }
 

--- a/client-sdk/src/external_api/contract/data_decoder.rs
+++ b/client-sdk/src/external_api/contract/data_decoder.rs
@@ -66,7 +66,7 @@ fn parse_block(
     decoded: &[Token],
 ) -> anyhow::Result<FullBlock> {
     let tx_tree_root = decoded
-        .get(0)
+        .first()
         .ok_or(anyhow::anyhow!("tx_tree_root not found"))?
         .clone()
         .into_fixed_bytes()
@@ -95,7 +95,7 @@ fn parse_block(
     let agg_pubkey = FlatG1(
         aggregated_public_key
             .iter()
-            .map(|e| U256::from_bytes_be(&e))
+            .map(|e| U256::from_bytes_be(e))
             .collect::<Vec<U256>>()
             .try_into()
             .map_err(|_| anyhow::anyhow!("aggregated_public_key is not FlatG1"))?,
@@ -116,7 +116,7 @@ fn parse_block(
     let agg_signature = FlatG2(
         aggregated_signature
             .iter()
-            .map(|e| U256::from_bytes_be(&e))
+            .map(|e| U256::from_bytes_be(e))
             .collect::<Vec<U256>>()
             .try_into()
             .map_err(|_| anyhow::anyhow!("aggregated_signature is not FlatG2"))?,
@@ -138,7 +138,7 @@ fn parse_block(
     let message_point = FlatG2(
         message_point
             .iter()
-            .map(|e| U256::from_bytes_be(&e))
+            .map(|e| U256::from_bytes_be(e))
             .collect::<Vec<U256>>()
             .try_into()
             .map_err(|_| anyhow::anyhow!("message_point is not FlatG2"))?,
@@ -175,9 +175,8 @@ fn parse_block(
     let account_id_hash = if is_registration_block {
         Bytes32::default()
     } else {
-        let account_ids_packed =
-            AccountIdPacked::from_trimmed_bytes(&account_ids.as_ref().unwrap())
-                .map_err(|e| anyhow::anyhow!("error while recovering packed account ids {}", e))?;
+        let account_ids_packed = AccountIdPacked::from_trimmed_bytes(account_ids.as_ref().unwrap())
+            .map_err(|e| anyhow::anyhow!("error while recovering packed account ids {}", e))?;
         account_ids_packed.hash()
     };
 

--- a/client-sdk/src/external_api/contract/handlers.rs
+++ b/client-sdk/src/external_api/contract/handlers.rs
@@ -46,11 +46,11 @@ pub async fn handle_contract_call<S: ToString, O: Detokenize>(
         }
         Err(e) => {
             let error_message = e.to_string();
-            return Err(BlockchainError::TransactionError(format!(
+            Err(BlockchainError::TransactionError(format!(
                 "{} failed with error: {:?}",
                 tx_name.to_string(),
                 error_message
-            )));
+            )))
         }
     }
 }
@@ -80,7 +80,7 @@ async fn send_tx_with_eip1559_gas_bump<S: ToString>(
                 let suggested_max_fee_per_gas = base_fee * 2 + priority_fee;
                 let max_fee_per_gas = current_tx
                     .max_fee_per_gas
-                    .unwrap_or_else(|| suggested_max_fee_per_gas);
+                    .unwrap_or(suggested_max_fee_per_gas);
                 let new_priority_fee = priority_fee * (100 + GAS_BUMP_PERCENTAGE) / 100;
                 let new_max_fee_per_gas = suggested_max_fee_per_gas
                     .max(max_fee_per_gas * (100 + GAS_BUMP_PERCENTAGE) / 100);
@@ -123,7 +123,7 @@ async fn send_tx_with_eip1559_gas_bump<S: ToString>(
             }
         }
     }
-    return Err(BlockchainError::MaxTxRetriesReached);
+    Err(BlockchainError::MaxTxRetriesReached)
 }
 
 async fn check_if_tx_succeeded(
@@ -142,11 +142,9 @@ async fn check_if_tx_succeeded(
                     tx_receipt.transaction_hash
                 )));
             }
-            return Ok(Some(tx_receipt.transaction_hash));
+            Ok(Some(tx_receipt.transaction_hash))
         }
-        None => {
-            return Ok(None);
-        }
+        None => Ok(None),
     }
 }
 

--- a/client-sdk/src/external_api/contract/liquidity_contract.rs
+++ b/client-sdk/src/external_api/contract/liquidity_contract.rs
@@ -58,6 +58,7 @@ impl LiquidityContract {
         self.address
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn initialize(
         &self,
         signer_private_key: H256,

--- a/client-sdk/src/external_api/contract/liquidity_contract.rs
+++ b/client-sdk/src/external_api/contract/liquidity_contract.rs
@@ -128,9 +128,9 @@ impl LiquidityContract {
         .await
         .map_err(|e| BlockchainError::RPCError(format!("Error getting token index: {:?}", e)))?;
         if !is_found {
-            return Ok(None);
+            Ok(None)
         } else {
-            return Ok(Some(token_index));
+            Ok(Some(token_index))
         }
     }
 
@@ -143,7 +143,7 @@ impl LiquidityContract {
             .await
             .map_err(|e| BlockchainError::RPCError(format!("Error getting token info: {:?}", e)))?;
 
-        let token_type: u8 = token_info.token_type.into();
+        let token_type: u8 = token_info.token_type;
         let token_type = TokenType::try_from(token_type)
             .map_err(|e| BlockchainError::ParseError(format!("Invalid token type: {:?}", e)))?;
         let token_address = Address::from_bytes_be(token_info.token_address.as_bytes());

--- a/client-sdk/src/external_api/contract/rollup_contract.rs
+++ b/client-sdk/src/external_api/contract/rollup_contract.rs
@@ -434,7 +434,7 @@ mod tests {
     #[tokio::test]
     async fn test_rollup_contract() -> anyhow::Result<()> {
         let anvil = Anvil::new().spawn();
-        let private_key: [u8; 32] = anvil.keys()[0].to_bytes().try_into().unwrap();
+        let private_key: [u8; 32] = anvil.keys()[0].to_bytes().into();
         let private_key = H256::from_slice(&private_key);
         let rpc_url = anvil.endpoint();
         let chain_id = anvil.chain_id();
@@ -471,7 +471,7 @@ mod tests {
         rollup_contract
             .post_non_registration_block(
                 private_key,
-                ethers::utils::parse_ether("1").unwrap().into(),
+                ethers::utils::parse_ether("1").unwrap(),
                 Bytes32::rand(&mut rng),
                 signature.sender_flag,
                 signature.agg_pubkey,

--- a/client-sdk/src/external_api/contract/rollup_contract.rs
+++ b/client-sdk/src/external_api/contract/rollup_contract.rs
@@ -296,6 +296,7 @@ impl RollupContract {
         Ok(tx_hash)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn post_registration_block(
         &self,
         signer_private_key: H256,
@@ -333,6 +334,7 @@ impl RollupContract {
         Ok(tx_hash)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn post_non_registration_block(
         &self,
         signer_private_key: H256,

--- a/client-sdk/src/external_api/contract/rollup_contract.rs
+++ b/client-sdk/src/external_api/contract/rollup_contract.rs
@@ -228,7 +228,7 @@ impl RollupContract {
         for (event, meta) in events {
             blocks_posted_events.push(BlockPosted {
                 prev_block_hash: Bytes32::from_bytes_be(&event.prev_block_hash),
-                block_builder: Address::from_bytes_be(&event.block_builder.as_bytes()),
+                block_builder: Address::from_bytes_be(event.block_builder.as_bytes()),
                 block_number: event.block_number.as_u32(),
                 deposit_tree_root: Bytes32::from_bytes_be(&event.deposit_tree_root),
                 signature_hash: Bytes32::from_bytes_be(&event.signature_hash),
@@ -258,7 +258,7 @@ impl RollupContract {
                 event.prev_block_hash,
                 event.deposit_tree_root,
                 event.block_number,
-                &tx.input.to_vec(),
+                &tx.input,
             )
             .map_err(|e| {
                 BlockchainError::DecodeCallDataError(format!(

--- a/client-sdk/src/external_api/store_vault_server.rs
+++ b/client-sdk/src/external_api/store_vault_server.rs
@@ -91,7 +91,7 @@ impl StoreVaultClientInterface for StoreVaultServerClient {
         };
         let response: SaveDataResponse = post_request(
             &self.base_url,
-            &format!("/store-vault-server/{}/save", data_type.to_string()),
+            &format!("/store-vault-server/{}/save", data_type),
             &request,
         )
         .await?;
@@ -106,7 +106,7 @@ impl StoreVaultClientInterface for StoreVaultServerClient {
         let request = BatchSaveDataRequest { requests: data };
         let response: BatchSaveDataResponse = post_request(
             &self.base_url,
-            &format!("/store-vault-server/{}/batch-save", data_type.to_string()),
+            &format!("/store-vault-server/{}/batch-save", data_type),
             &request,
         )
         .await?;
@@ -123,7 +123,7 @@ impl StoreVaultClientInterface for StoreVaultServerClient {
         };
         let response: GetDataResponse = get_request(
             &self.base_url,
-            &format!("/store-vault-server/{}/get", data_type.to_string()),
+            &format!("/store-vault-server/{}/get", data_type),
             Some(query),
         )
         .await?;
@@ -140,7 +140,7 @@ impl StoreVaultClientInterface for StoreVaultServerClient {
         };
         let response: BatchGetDataResponse = get_request(
             &self.base_url,
-            &format!("/store-vault-server/{}/batch-get", data_type.to_string()),
+            &format!("/store-vault-server/{}/batch-get", data_type),
             Some(query),
         )
         .await?;
@@ -156,10 +156,7 @@ impl StoreVaultClientInterface for StoreVaultServerClient {
         let query = GetDataAllAfterQuery { pubkey, timestamp };
         let response: GetDataAllAfterResponse = get_request(
             &self.base_url,
-            &format!(
-                "/store-vault-server/{}/get-all-after",
-                data_type.to_string()
-            ),
+            &format!("/store-vault-server/{}/get-all-after", data_type),
             Some(query),
         )
         .await?;

--- a/client-sdk/src/external_api/utils/query.rs
+++ b/client-sdk/src/external_api/utils/query.rs
@@ -74,18 +74,18 @@ async fn handle_response<R: DeserializeOwned>(
             .await
             .unwrap_or_else(|_| "Failed to read error response".to_string());
         let error_message = match serde_json::from_str::<ErrorResponse>(&error_text) {
-            Ok(error_resp) => error_resp.message.unwrap_or_else(|| error_resp.error),
+            Ok(error_resp) => error_resp.message.unwrap_or(error_resp.error),
             Err(_) => error_text,
         };
         let abr_request = if is_debug_mode() {
             // full request string
-            request_str.clone().unwrap_or_else(|| "".to_string())
+            request_str.clone().unwrap_or_default()
         } else {
             // Truncate the request string to 500 characters if it is too long
             request_str
                 .as_ref()
                 .map(|s| s.chars().take(500).collect::<String>())
-                .unwrap_or_else(|| "".to_string())
+                .unwrap_or_default()
         };
         return Err(ServerError::ServerError(
             status.into(),

--- a/interfaces/src/api/store_vault_server/interface.rs
+++ b/interfaces/src/api/store_vault_server/interface.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use async_trait::async_trait;
 use intmax2_zkp::{ethereum_types::u256::U256, utils::poseidon_hash_out::PoseidonHashOut};
@@ -23,14 +23,15 @@ pub enum DataType {
     Tx,
 }
 
-impl ToString for DataType {
-    fn to_string(&self) -> String {
-        match self {
+impl fmt::Display for DataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let t = match self {
             DataType::Deposit => "deposit".to_string(),
             DataType::Transfer => "transfer".to_string(),
             DataType::Withdrawal => "withdrawal".to_string(),
             DataType::Tx => "tx".to_string(),
-        }
+        };
+        write!(f, "{}", t)
     }
 }
 
@@ -102,4 +103,19 @@ pub trait StoreVaultClientInterface {
     ) -> Result<(), ServerError>;
 
     async fn get_user_data(&self, pubkey: U256) -> Result<Option<Vec<u8>>, ServerError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DataType;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_data_type() {
+        let deposit = DataType::from_str("deposit").unwrap();
+        assert_eq!(deposit.to_string(), "deposit");
+
+        let withdrawal = DataType::Withdrawal;
+        assert_eq!(withdrawal.to_string(), "withdrawal");
+    }
 }

--- a/interfaces/src/data/deposit_data.rs
+++ b/interfaces/src/data/deposit_data.rs
@@ -113,23 +113,15 @@ impl DepositData {
     }
 
     pub fn deposit(&self) -> Option<Deposit> {
-        if let Some(token_index) = self.token_index {
-            Some(Deposit {
-                pubkey_salt_hash: self.pubkey_salt_hash,
-                token_index,
-                amount: self.amount,
-            })
-        } else {
-            None
-        }
+        self.token_index.map(|token_index| Deposit {
+            pubkey_salt_hash: self.pubkey_salt_hash,
+            token_index,
+            amount: self.amount,
+        })
     }
 
     pub fn deposit_hash(&self) -> Option<Bytes32> {
-        if let Some(deposit) = self.deposit() {
-            Some(deposit.hash())
-        } else {
-            None
-        }
+        self.deposit().map(|deposit| deposit.hash())
     }
 }
 

--- a/interfaces/src/data/deposit_data.rs
+++ b/interfaces/src/data/deposit_data.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use anyhow::{bail, ensure};
 use serde::{Deserialize, Serialize};
@@ -53,14 +53,15 @@ impl FromStr for TokenType {
     }
 }
 
-impl ToString for TokenType {
-    fn to_string(&self) -> String {
-        match self {
+impl fmt::Display for TokenType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let t = match self {
             Self::NATIVE => "NATIVE".to_string(),
             Self::ERC20 => "ERC20".to_string(),
             Self::ERC721 => "ERC721".to_string(),
             Self::ERC1155 => "ERC1155".to_string(),
-        }
+        };
+        write!(f, "{}", t)
     }
 }
 
@@ -129,5 +130,20 @@ impl DepositData {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TokenType;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_token_type() {
+        let native = TokenType::from_str("NATIVE").unwrap();
+        assert_eq!(native.to_string(), "NATIVE");
+
+        let erc721 = TokenType::ERC721;
+        assert_eq!(erc721.to_string(), "ERC721");
     }
 }

--- a/store-vault-server/src/api/api.rs
+++ b/store-vault-server/src/api/api.rs
@@ -28,7 +28,7 @@ pub async fn save_balance_proof(
         .store_vault_server
         .save_balance_proof(request.pubkey, request.balance_proof)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 
@@ -42,7 +42,7 @@ pub async fn get_balance_proof(
         .store_vault_server
         .get_balance_proof(query.pubkey, query.block_number, query.private_commitment)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetBalanceProofResponse { balance_proof }))
 }
 
@@ -60,7 +60,7 @@ pub async fn save_data(
         .store_vault_server
         .save_data(data_type, request.pubkey, request.data)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(SaveDataResponse { uuid }))
 }
 
@@ -89,7 +89,7 @@ pub async fn batch_save_data(
         .store_vault_server
         .batch_save_data(data_type, requests)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(Json(BatchSaveDataResponse { uuids }))
 }
@@ -108,7 +108,7 @@ pub async fn get_data(
         .store_vault_server
         .get_data(data_type, &query.uuid)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetDataResponse { data }))
 }
 
@@ -137,7 +137,7 @@ pub async fn batch_get_data(
         .store_vault_server
         .batch_get_data(data_type, &uuids)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(Json(BatchGetDataResponse { data }))
 }
@@ -156,7 +156,7 @@ pub async fn get_data_all_after(
         .store_vault_server
         .get_data_all_after(data_type, query.pubkey, query.timestamp)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetDataAllAfterResponse { data }))
 }
 
@@ -170,7 +170,7 @@ pub async fn save_user_data(
         .store_vault_server
         .save_user_data(request.pubkey, request.data)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 
@@ -184,7 +184,7 @@ pub async fn get_user_data(
         .store_vault_server
         .get_user_data(query.pubkey)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetUserDataResponse { data }))
 }
 

--- a/store-vault-server/src/api/mod.rs
+++ b/store-vault-server/src/api/mod.rs
@@ -1,2 +1,3 @@
+#[allow(clippy::module_inception)]
 pub mod api;
 pub mod state;

--- a/store-vault-server/src/app/store_vault_server.rs
+++ b/store-vault-server/src/app/store_vault_server.rs
@@ -163,7 +163,7 @@ impl StoreVaultServer {
     ) -> Result<String> {
         let pubkey_hex = pubkey.to_hex();
         let uuid = Uuid::new_v4().to_string();
-        let timestamp = chrono::Utc::now().timestamp() as i64;
+        let timestamp = chrono::Utc::now().timestamp();
 
         sqlx::query!(
             r#"
@@ -188,7 +188,7 @@ impl StoreVaultServer {
         data_type: DataType,
         requests: Vec<(U256, Vec<u8>)>,
     ) -> Result<Vec<String>> {
-        let timestamp = chrono::Utc::now().timestamp() as i64;
+        let timestamp = chrono::Utc::now().timestamp();
 
         // Prepare values for bulk insert
         let pubkeys: Vec<String> = requests.iter().map(|(pubkey, _)| pubkey.to_hex()).collect();

--- a/validity-prover/src/api/api.rs
+++ b/validity-prover/src/api/api.rs
@@ -20,7 +20,7 @@ pub async fn get_block_number(state: Data<State>) -> Result<Json<GetBlockNumberR
         .validity_prover
         .get_block_number()
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetBlockNumberResponse { block_number }))
 }
 
@@ -32,7 +32,7 @@ pub async fn get_next_deposit_index(
         .validity_prover
         .get_next_deposit_index()
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetNextDepositIndexResponse { deposit_index }))
 }
 
@@ -46,7 +46,7 @@ pub async fn get_account_info(
         .validity_prover
         .get_account_info(query.pubkey)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetAccountInfoResponse { account_info }))
 }
 
@@ -65,7 +65,7 @@ pub async fn get_update_witness(
             query.is_prev_account_tree,
         )
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetUpdateWitnessResponse { update_witness }))
 }
 
@@ -79,7 +79,7 @@ pub async fn get_deposit_info(
         .validity_prover
         .get_deposit_info(query.deposit_hash)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetDepositInfoResponse { deposit_info }))
 }
 
@@ -93,7 +93,7 @@ pub async fn get_block_number_by_tx_tree_root(
         .validity_prover
         .get_block_number_by_tx_tree_root(query.tx_tree_root)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetBlockNumberByTxTreeRootResponse { block_number }))
 }
 
@@ -107,7 +107,7 @@ pub async fn get_validity_pis(
         .validity_prover
         .get_validity_pis(query.block_number)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetValidityPisResponse { validity_pis }))
 }
 
@@ -121,7 +121,7 @@ pub async fn get_sender_leaves(
         .validity_prover
         .get_sender_leaves(query.block_number)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetSenderLeavesResponse { sender_leaves }))
 }
 
@@ -135,7 +135,7 @@ pub async fn get_block_merkle_proof(
         .validity_prover
         .get_block_merkle_proof(query.root_block_number, query.leaf_block_number)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetBlockMerkleProofResponse { block_merkle_proof }))
 }
 
@@ -149,7 +149,7 @@ pub async fn get_deposit_merkle_proof(
         .validity_prover
         .get_deposit_merkle_proof(query.block_number, query.deposit_index)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetDepositMerkleProofResponse {
         deposit_merkle_proof,
     }))

--- a/validity-prover/src/api/mod.rs
+++ b/validity-prover/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod api;
 pub mod error;
 pub mod observer;

--- a/validity-prover/src/api/validity_prover.rs
+++ b/validity-prover/src/api/validity_prover.rs
@@ -43,8 +43,11 @@ type F = GoldilocksField;
 type C = PoseidonGoldilocksConfig;
 const D: usize = 2;
 
+#[allow(clippy::upper_case_acronyms)]
 type ADB = SqlMerkleTree<IndexedMerkleLeaf>;
+#[allow(clippy::upper_case_acronyms)]
 type BDB = SqlMerkleTree<Bytes32>;
+#[allow(clippy::upper_case_acronyms)]
 type DDB = SqlMerkleTree<DepositHash>;
 
 const ACCOUNT_DB_TAG: u32 = 1;
@@ -435,7 +438,6 @@ impl ValidityProver {
     }
 
     pub fn validity_processor(&self) -> &ValidityProcessor<F, C, D> {
-        self.validity_processor
-            .get_or_init(|| ValidityProcessor::new())
+        self.validity_processor.get_or_init(ValidityProcessor::new)
     }
 }

--- a/validity-prover/src/trees/account_tree.rs
+++ b/validity-prover/src/trees/account_tree.rs
@@ -36,21 +36,21 @@ impl<DB: MerkleTreeClient<V>> HistoricalAccountTree<DB> {
     pub async fn prove_membership(&self, timestamp: u64, key: U256) -> Result<MembershipProof> {
         if let Some(index) = self.index(timestamp, key).await? {
             // inclusion proof
-            return Ok(MembershipProof {
+            Ok(MembershipProof {
                 is_included: true,
                 leaf_index: index,
                 leaf: self.0.get_leaf(timestamp, index).await?,
                 leaf_proof: self.0.prove(timestamp, index).await?,
-            });
+            })
         } else {
             // exclusion proof
             let low_index = self.low_index(timestamp, key).await?; // unwrap is safe here
-            return Ok(MembershipProof {
+            Ok(MembershipProof {
                 is_included: false,
                 leaf_index: low_index,
                 leaf: self.0.get_leaf(timestamp, low_index).await?,
                 leaf_proof: self.0.prove(timestamp, low_index).await?,
-            });
+            })
         }
     }
 

--- a/validity-prover/src/trees/indexed_merkle_tree.rs
+++ b/validity-prover/src/trees/indexed_merkle_tree.rs
@@ -45,7 +45,7 @@ impl<DB: MerkleTreeClient<V>> HistoricalIndexedMerkleTree<DB> {
                 (leaf.key < key) && (key < leaf.next_key || leaf.next_key == U256::default())
             })
             .collect::<Vec<_>>();
-        ensure!(0 < low_leaf_candidates.len(), "key already exists");
+        ensure!(!low_leaf_candidates.is_empty(), "key already exists");
         ensure!(
             low_leaf_candidates.len() == 1,
             "low_index: too many candidates"

--- a/validity-prover/src/trees/merkle_tree/mock_merkle_tree.rs
+++ b/validity-prover/src/trees/merkle_tree/mock_merkle_tree.rs
@@ -38,7 +38,7 @@ impl<V: Leafable + Serialize + DeserializeOwned> MockMerkleTree<V> {
     pub fn new(height: usize) -> Self {
         let mut zero_hashes = vec![];
         let mut h = V::empty_leaf().hash();
-        zero_hashes.push(h.clone());
+        zero_hashes.push(h);
         for _ in 0..height {
             let new_h = Hasher::<V>::two_to_one(h, h);
             zero_hashes.push(new_h);
@@ -229,8 +229,8 @@ impl<V: Leafable + Serialize + DeserializeOwned> MockMerkleTree<V> {
     async fn get_last_timestamp(&self) -> u64 {
         let leaves = self.leaves.read().await.clone();
         let last_timestamp = leaves
-            .iter()
-            .map(|(_, leaves)| {
+            .values()
+            .map(|leaves| {
                 leaves
                     .iter()
                     .map(|leaf| leaf.timestamp_value)

--- a/validity-prover/src/trees/merkle_tree/sql_merkle_tree.rs
+++ b/validity-prover/src/trees/merkle_tree/sql_merkle_tree.rs
@@ -27,7 +27,7 @@ impl<V: Leafable + Serialize + DeserializeOwned> SqlMerkleTree<V> {
 
         let mut zero_hashes = vec![];
         let mut h = V::empty_leaf().hash();
-        zero_hashes.push(h.clone());
+        zero_hashes.push(h);
         for _ in 0..height {
             let new_h = Hasher::<V>::two_to_one(h, h);
             zero_hashes.push(new_h);

--- a/validity-prover/src/trees/mod.rs
+++ b/validity-prover/src/trees/mod.rs
@@ -23,6 +23,5 @@ pub fn setup_test() -> String {
         )
         .try_init()
         .unwrap();
-    let database_url = std::env::var("DATABASE_URL").unwrap();
-    database_url
+    std::env::var("DATABASE_URL").unwrap()
 }

--- a/validity-prover/src/trees/utils/bit_path.rs
+++ b/validity-prover/src/trees/utils/bit_path.rs
@@ -89,17 +89,17 @@ mod tests {
     #[test]
     fn test_bit_path() {
         let mut path = BitPath::new(0, 0);
-        assert_eq!(path.is_empty(), true);
+        assert!(path.is_empty());
         assert_eq!(path.len(), 0);
         assert_eq!(path.value(), 0);
 
         path.push(true);
-        assert_eq!(path.is_empty(), false);
+        assert!(!path.is_empty());
         assert_eq!(path.len(), 1);
         assert_eq!(path.value(), 1);
 
         path.push(false);
-        assert_eq!(path.is_empty(), false);
+        assert!(!path.is_empty());
         assert_eq!(path.len(), 2);
         assert_eq!(path.value(), 1);
 
@@ -109,17 +109,17 @@ mod tests {
         assert_eq!(recovered_path, path);
 
         assert_eq!(path.pop(), Some(false));
-        assert_eq!(path.is_empty(), false);
+        assert!(!path.is_empty());
         assert_eq!(path.len(), 1);
         assert_eq!(path.value(), 1);
 
         assert_eq!(path.pop(), Some(true));
-        assert_eq!(path.is_empty(), true);
+        assert!(path.is_empty());
         assert_eq!(path.len(), 0);
         assert_eq!(path.value(), 0);
 
         assert_eq!(path.pop(), None);
-        assert_eq!(path.is_empty(), true);
+        assert!(path.is_empty());
         assert_eq!(path.len(), 0);
         assert_eq!(path.value(), 0);
     }

--- a/validity-prover/src/trees/utils/bit_path.rs
+++ b/validity-prover/src/trees/utils/bit_path.rs
@@ -24,7 +24,7 @@ impl BitPath {
     }
 
     pub fn push(&mut self, bit: bool) {
-        self.value |= ((bit as u64) << self.length);
+        self.value |= (bit as u64) << self.length;
         self.length += 1;
     }
 
@@ -67,7 +67,7 @@ impl BitPath {
         // flip the last bit
         let mut path = *self;
         let last = path.len() - 1;
-        path.value ^= (1 << last);
+        path.value ^= 1 << last;
         path
     }
 

--- a/validity-prover/src/trees/utils/bit_path.rs
+++ b/validity-prover/src/trees/utils/bit_path.rs
@@ -24,7 +24,7 @@ impl BitPath {
     }
 
     pub fn push(&mut self, bit: bool) {
-        self.value = self.value | ((bit as u64) << self.length);
+        self.value |= ((bit as u64) << self.length);
         self.length += 1;
     }
 
@@ -34,13 +34,13 @@ impl BitPath {
         }
         let bit = (self.value >> (self.length - 1)) & 1;
         // mask out the bit
-        self.value = self.value & !(1 << (self.length - 1));
+        self.value &= !(1 << (self.length - 1));
         self.length -= 1;
         Some(bit == 1)
     }
 
     pub fn to_bits_le(&self) -> Vec<bool> {
-        let mut s = self.clone();
+        let mut s = *self;
         let mut bits = Vec::new();
         while !s.is_empty() {
             bits.push(s.pop().unwrap());
@@ -65,9 +65,9 @@ impl BitPath {
 
     pub fn sibling(&self) -> Self {
         // flip the last bit
-        let mut path = self.clone();
+        let mut path = *self;
         let last = path.len() - 1;
-        path.value = path.value ^ (1 << last);
+        path.value ^= (1 << last);
         path
     }
 

--- a/wasm/src/client.rs
+++ b/wasm/src/client.rs
@@ -81,6 +81,7 @@ pub struct Config {
 
 #[wasm_bindgen]
 impl Config {
+    #[allow(clippy::too_many_arguments)]
     #[wasm_bindgen(constructor)]
     pub fn new(
         store_vault_server_url: String,

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -51,6 +51,7 @@ pub async fn generate_intmax_account_from_eth_key(
 }
 
 /// Function to take a backup before calling the deposit function of the liquidity contract.
+///
 /// You can also get the pubkey_salt_hash from the return value.
 #[wasm_bindgen]
 pub async fn prepare_deposit(
@@ -71,12 +72,7 @@ pub async fn prepare_deposit(
     let deposit_result = client
         .prepare_deposit(recipient, amount, token_type, token_address, token_id)
         .await
-        .map_err(|e| {
-            JsError::new(&format!(
-                "failed to prepare deposit call: {}",
-                e.to_string()
-            ))
-        })?;
+        .map_err(|e| JsError::new(&format!("failed to prepare deposit call: {}", e)))?;
     Ok(JsDepositResult::from_deposit_result(&deposit_result))
 }
 
@@ -134,6 +130,7 @@ pub async fn query_proposal(
 }
 
 /// Send the signed tx tree root to the block builder during taking a backup of the tx.
+///
 /// You need to call send_tx_request before calling this function.
 /// The return value is the tx result, which contains the tx tree root and transfer data.
 #[wasm_bindgen]
@@ -168,14 +165,14 @@ pub async fn query_and_finalize(
     let client = get_client(config);
     let tx_request_memo = tx_request_memo.to_tx_request_memo()?;
     let is_registration_block = tx_request_memo.is_registration_block;
-    let tx = tx_request_memo.tx.clone();
+    let tx = tx_request_memo.tx;
     let mut tries = 0;
     let proposal = loop {
         let proposal = client
-            .query_proposal(&block_builder_url, key, is_registration_block, tx)
+            .query_proposal(block_builder_url, key, is_registration_block, tx)
             .await?;
-        if proposal.is_some() {
-            break proposal.unwrap();
+        if let Some(p) = proposal {
+            break p;
         }
         if tries > config.block_builder_query_limit {
             return Err(JsError::new("Failed to get proposal"));
@@ -184,7 +181,7 @@ pub async fn query_and_finalize(
         sleep_for(config.block_builder_query_interval).await;
     };
     let tx_result = client
-        .finalize_tx(&block_builder_url, key, &tx_request_memo, &proposal)
+        .finalize_tx(block_builder_url, key, &tx_request_memo, &proposal)
         .await?;
     Ok(JsTxResult::from_tx_result(&tx_result))
 }

--- a/withdrawal-server/src/api/api.rs
+++ b/withdrawal-server/src/api/api.rs
@@ -32,7 +32,7 @@ pub async fn request_withdrawal(
         .withdrawal_server
         .request_withdrawal(request.pubkey, &request.single_withdrawal_proof)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(()))
 }
 
@@ -45,7 +45,7 @@ pub async fn get_withdrawal_info(
         .withdrawal_server
         .get_withdrawal_info(query.pubkey, query.signature.clone())
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
 
     Ok(Json(GetWithdrawalInfoResponse { withdrawal_info }))
 }
@@ -59,7 +59,7 @@ pub async fn get_withdrawal_info_by_recipient(
         .withdrawal_server
         .get_withdrawal_info_by_recipient(query.recipient)
         .await
-        .map_err(|e| actix_web::error::ErrorInternalServerError(e))?;
+        .map_err(actix_web::error::ErrorInternalServerError)?;
     Ok(Json(GetWithdrawalInfoResponse { withdrawal_info }))
 }
 

--- a/withdrawal-server/src/api/mod.rs
+++ b/withdrawal-server/src/api/mod.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::module_inception)]
 pub mod api;
 pub mod encode;
 pub mod error;

--- a/withdrawal-server/src/api/status.rs
+++ b/withdrawal-server/src/api/status.rs
@@ -23,9 +23,9 @@ impl From<WithdrawalStatus> for SqlWithdrawalStatus {
     }
 }
 
-impl Into<WithdrawalStatus> for SqlWithdrawalStatus {
-    fn into(self) -> WithdrawalStatus {
-        match self {
+impl From<SqlWithdrawalStatus> for WithdrawalStatus {
+    fn from(val: SqlWithdrawalStatus) -> Self {
+        match val {
             SqlWithdrawalStatus::Requested => WithdrawalStatus::Requested,
             SqlWithdrawalStatus::Relayed => WithdrawalStatus::Relayed,
             SqlWithdrawalStatus::Success => WithdrawalStatus::Success,


### PR DESCRIPTION
Added Rust's lint tool clippy to pre-commit hook and fixed all existing warnings.
Also improved processing speed by parallelizing pre-commit execution.

## Changes

* Added cargo clippy to lefthook pre-commit (treating warnings as errors)
* Enabled parallel execution with parallel: true
* Fixed code to address clippy warnings

## Pros

* Improves code quality (added static analysis with clippy)
* Enables early detection of potential issues before commit
