### PR TITLE
Fix Rust toolchain versioning and add caching in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,13 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
       - name: cargo fmt
         run: cargo fmt --check --all
+
   doc:
     name: doc
     runs-on: ubuntu-latest
@@ -34,8 +39,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
       - name: Check docs
         run: cargo doc --no-deps
+
   typos:
     name: typos
     runs-on: ubuntu-latest
@@ -43,6 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: typos-action
         uses: crate-ci/typos@master
+
   clippy:
     name: clippy
     needs: format-check
@@ -53,9 +64,14 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
       - uses: r7kamura/rust-problem-matchers@v1
       - name: cargo clippy
         run: cargo clippy --tests -- -D warnings -D "clippy::perf" -D "clippy::correctness"
+
   tests:
     name: tests
     needs: clippy
@@ -80,6 +96,12 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-build"
+          cache-on-failure: true
+          max-size: 5G  # set max-size and cache-max-age, because this is last job
+          cache-max-age: 168 # 7 days in hours
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,8 +100,6 @@ jobs:
         with:
           shared-key: "rust-build"
           cache-on-failure: true
-          max-size: 5G  # set max-size and cache-max-age, because this is last job
-          cache-max-age: 168 # 7 days in hours
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,6 @@ jobs:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-build"
           cache-on-failure: true
       - name: cargo fmt
         run: cargo fmt --check --all
@@ -41,7 +40,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-build"
           cache-on-failure: true
       - name: Check docs
         run: cargo doc --no-deps
@@ -66,7 +64,6 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-build"
           cache-on-failure: true
       - uses: r7kamura/rust-problem-matchers@v1
       - name: cargo clippy
@@ -98,7 +95,6 @@ jobs:
           toolchain: stable
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-build"
           cache-on-failure: true
       - uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: nightly-2024-09-17
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
@@ -37,7 +38,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly-2024-09-17
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -59,8 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@v1
         with:
+          toolchain: nightly-2024-09-17
           components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -92,7 +96,7 @@ jobs:
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly-2024-09-17
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true


### PR DESCRIPTION
Unified Rust toolchain settings and introduced caching in CI workflow.

## Changes

* Fixed all jobs to use `nightly-2024-09-17` toolchain, because settings by `rust-toolchain.toml`
  * Previously mixed between stable and nightly (unversioned)
* Added Swatinem/rust-cache to all jobs

## Pros

* Improves CI reproducibility through fixed toolchain version
* Significantly reduces CI execution time (from ~8min to ~4min) with caching
