### PR TITLE
remove members's rust-toolchain toml

### DIFF
--- a/cli/rust-toolchain.toml
+++ b/cli/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2024-09-17"

--- a/client-sdk/rust-toolchain.toml
+++ b/client-sdk/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2024-09-17"

--- a/interfaces/rust-toolchain.toml
+++ b/interfaces/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2024-09-17"

--- a/wasm/rust-toolchain.toml
+++ b/wasm/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly-2024-09-17"


### PR DESCRIPTION
## Changes

* Removed rust-toolchain.toml from sub-directories
* Unified to use rust-toolchain.toml at repository root

## Pros
* Centralizes Rust toolchain configuration management
* Eliminates risk of inconsistencies from duplicate settings