### PR TITLE
Add docker compose for local env

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cargo test -r -p tests deploy_contracts -- --nocapture
 
 Launch database
 ```bash
-docker run --name postgres -e POSTGRES_PASSWORD=password -p 5432:5432 -d postgres
+docker compose up -d db
 ```
 
 Copy env file 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,36 @@
+services:
+  db:
+    image: postgres:15.8
+    container_name: intmax_postgres
+    restart: always
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: postgres
+      TZ: UTC
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  tempo:
+    image: grafana/tempo:latest
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./docker/tempo.local.yaml:/etc/tempo.yaml
+    ports:
+      - "4317:4317"  # OTLP gRPC
+      - "4318:4318"  # OTLP HTTP
+      - "3200:3200"  # Tempo endpoint
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+
+volumes:
+  postgres_data:
+    name: postgres_data

--- a/docker/tempo.local.yaml
+++ b/docker/tempo.local.yaml
@@ -1,0 +1,17 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+        http:
+          endpoint: "0.0.0.0:4318"
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks


### PR DESCRIPTION
Updated local environment setup to use Docker Compose.

## Changes

* Added compose.yml, use with postgres, tempo, grafana

## Pros
* Simplified environment setup with single docker compose up -d command
* Easy environment sharing across all developers