### PR TITLE
Fix deposit observer bug

### DIFF
--- a/client-sdk/src/external_api/contract/rollup_contract.rs
+++ b/client-sdk/src/external_api/contract/rollup_contract.rs
@@ -408,6 +408,16 @@ impl RollupContract {
                 })?;
         Ok(latest_block_number)
     }
+
+    pub async fn get_next_deposit_index(&self) -> Result<u32, BlockchainError> {
+        let contract = self.get_contract().await?;
+        let next_deposit_index = with_retry(|| async { contract.deposit_index().call().await })
+            .await
+            .map_err(|_| {
+                BlockchainError::RPCError("failed to get latest block number".to_string())
+            })?;
+        Ok(next_deposit_index)
+    }
 }
 
 fn encode_flat_g1(g1: &FlatG1) -> [[u8; 32]; 2] {

--- a/validity-prover/src/app/observer.rs
+++ b/validity-prover/src/app/observer.rs
@@ -311,6 +311,15 @@ impl Observer {
                     first.deposit_index, next_deposit_index
                 )));
             }
+        } else {
+            // no new deposits
+            let rollup_next_deposit_index = self.rollup_contract.get_next_deposit_index().await?;
+            if next_deposit_index < rollup_next_deposit_index {
+                return Err(ObserverError::FullBlockSyncError(format!(
+                    "next_deposit_index is less than rollup_next_deposit_index: {} < {}",
+                    next_deposit_index, rollup_next_deposit_index
+                )));
+            }
         }
         Ok((deposit_leaf_events, to_block))
     }


### PR DESCRIPTION
When deposit events obtained from RPC are missing, deposit_sync_eth_block_num might advance while some deposits are overlooked. To address this, I implemented periodic checks of the deposit index from the rollup contract. If any deposits are found to be missed, the system will raise an error and roll back deposit_sync_eth_block_num to ensure no deposits are skipped.

